### PR TITLE
add user client and get current user method

### DIFF
--- a/internal/build/docker-compose.yaml
+++ b/internal/build/docker-compose.yaml
@@ -19,9 +19,12 @@ services:
   gofumpt:
     extends:
       service: base-lint
-    command: ["gofumpt", "-w", "-l","."]
+    command: ["gofumpt", "-w", "-l","internal/", "xata/*.go"] # TODO: Fix xata/*.go: no such file or directory
 
   lint:
     extends:
       service: base-lint
+    depends_on:
+      gofumpt:
+        condition: service_completed_successfully
     command: ["golangci-lint", "run"]

--- a/internal/integration-tests/users_client_test.go
+++ b/internal/integration-tests/users_client_test.go
@@ -1,0 +1,33 @@
+package integrationtests
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/xataio/xata-go/xata"
+)
+
+func Test_usersClient(t *testing.T) {
+	apiKey, found := os.LookupEnv("XATA_API_KEY")
+	if !found {
+		t.Skipf("%s not found in env vars", "XATA_API_KEY")
+	}
+
+	t.Run("should get the current user", func(t *testing.T) {
+		usersCli, err := xata.NewUsersClient(
+			xata.WithAPIKey(apiKey),
+			xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()),
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		user, err := usersCli.Get(context.TODO())
+		assert.NoError(t, err)
+		assert.NotNil(t, user)
+	})
+}

--- a/internal/integration-tests/workspaces_client_test.go
+++ b/internal/integration-tests/workspaces_client_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/xataio/xata-go/xata"
 )
 
@@ -17,7 +17,10 @@ func Test_workspacesClient(t *testing.T) {
 	}
 
 	t.Run("should create, get, list, update and delete workspace", func(t *testing.T) {
-		workspaceCli, err := xata.NewWorkspacesClient(xata.WithAPIKey(apiKey))
+		workspaceCli, err := xata.NewWorkspacesClient(
+			xata.WithAPIKey(apiKey),
+			xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()),
+		)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/smoke-tests/main.go
+++ b/internal/smoke-tests/main.go
@@ -151,4 +151,16 @@ func main() {
 	}
 
 	fmt.Println("table status", delTableResponse.Status.String())
+
+	usersCli, err := xata.NewUsersClient(xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	user, err := usersCli.Get(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(user)
 }

--- a/xata/users_client.go
+++ b/xata/users_client.go
@@ -1,0 +1,36 @@
+package xata
+
+import (
+	"context"
+
+	xatagencore "github.com/xataio/xata-go/xata/internal/fern-core/generated/go"
+	xatagenclient "github.com/xataio/xata-go/xata/internal/fern-core/generated/go/core"
+)
+
+type UsersClient interface {
+	Get(ctx context.Context) (*xatagencore.UserWithId, error)
+}
+
+type usersCli struct {
+	generated xatagencore.UsersClient
+}
+
+func (u usersCli) Get(ctx context.Context) (*xatagencore.UserWithId, error) {
+	return u.generated.GetUser(ctx)
+}
+
+func NewUsersClient(opts ...ClientOption) (UsersClient, error) {
+	cliOpts, err := consolidateClientOptionsForCore(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return usersCli{
+		generated: xatagencore.NewUsersClient(
+			func(options *xatagenclient.ClientOptions) {
+				options.HTTPClient = cliOpts.HTTPClient
+				options.BaseURL = cliOpts.BaseURL
+				options.Bearer = cliOpts.Bearer
+			}),
+	}, nil
+}

--- a/xata/users_client_test.go
+++ b/xata/users_client_test.go
@@ -1,0 +1,77 @@
+package xata_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xataio/xata-go/xata"
+	xatagen "github.com/xataio/xata-go/xata/internal/fern-core/generated/go"
+	xatagencore "github.com/xataio/xata-go/xata/internal/fern-core/generated/go/core"
+)
+
+func TestNewUsersClient(t *testing.T) {
+	t.Run("should construct a new users client", func(t *testing.T) {
+		got, err := xata.NewUsersClient(xata.WithAPIKey("my-api-token"))
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+}
+
+func Test_usersCli_Get(t *testing.T) {
+	assert := assert.New(t)
+
+	type tc struct {
+		name       string
+		want       *xatagen.UserWithId
+		statusCode int
+		apiErr     *xatagencore.APIError
+	}
+
+	tests := []tc{
+		{
+			name: "should get current user",
+			want: &xatagen.UserWithId{
+				Email:    "email@test.com",
+				Fullname: "name lastname",
+				Image:    "some-image",
+				Id:       "some-id",
+			},
+			statusCode: http.StatusOK,
+		},
+	}
+
+	for _, eTC := range errTestCasesCore {
+		tests = append(tests, tc{
+			name:       eTC.name,
+			statusCode: eTC.statusCode,
+			apiErr:     eTC.apiErr,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testSrv := testService(t, http.MethodGet, "/user", tt.statusCode, tt.apiErr != nil, tt.want)
+
+			cli, err := xata.NewUsersClient(xata.WithBaseURL(testSrv.URL), xata.WithAPIKey("test-key"))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			user, err := cli.Get(context.TODO())
+
+			if tt.apiErr != nil {
+				errAPI := tt.apiErr.Unwrap()
+				if errAPI == nil {
+					t.Fatal("expected error but got nil")
+				}
+				assert.ErrorAs(err, &errAPI)
+				assert.Equal(err.Error(), tt.apiErr.Error())
+			} else {
+				assert.NoError(err)
+				assert.Equal(tt.want, user)
+			}
+		})
+	}
+}

--- a/xata/workspaces_client_test.go
+++ b/xata/workspaces_client_test.go
@@ -240,7 +240,7 @@ func Test_workspacesClient_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testSrv := testService(t, http.MethodDelete, "", tt.statusCode, tt.apiErr != nil, nil)
+			testSrv := testService(t, http.MethodDelete, "/workspaces", tt.statusCode, tt.apiErr != nil, nil)
 
 			wsCli, err := xata.NewWorkspacesClient(xata.WithBaseURL(testSrv.URL), xata.WithAPIKey("test-key"))
 			if err != nil {


### PR DESCRIPTION
Add `users client` and following endpoint support
[get current user](https://xata.io/docs/api-reference/user#get-user-details): GET /user