### PR TITLE
Switch from Go 1.21.0 to 1.21 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xataio/xata-go
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
This is less strict and allows projects importing this library to use any Go 1.21.x version.