### PR TITLE
Add env vars for Workspace, Region and Branch

### DIFF
--- a/internal/integration-tests/table_client_test.go
+++ b/internal/integration-tests/table_client_test.go
@@ -5,7 +5,6 @@ package integrationtests
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,90 +14,51 @@ import (
 )
 
 func Test_tableClient(t *testing.T) {
-	apiKey, found := os.LookupEnv("XATA_API_KEY")
-	if !found {
-		t.Skipf("%s not found in env vars", "XATA_API_KEY")
+	cfg, err := setupDatabase()
+	if err != nil {
+		t.Fatalf("unable to setup database: %v", err)
+	}
+
+	t.Cleanup(func() {
+		err = cleanup(cfg)
+		if err != nil {
+			t.Fatalf("unable to cleanup test setup: %v", err)
+		}
+	})
+
+	databaseCli, err := xata.NewDatabasesClient(
+		xata.WithAPIKey(cfg.apiKey),
+		xata.WithBaseURL(fmt.Sprintf(
+			"https://%s.%s.xata.sh",
+			cfg.wsID,
+			cfg.region,
+		)),
+		xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tableCli, err := xata.NewTableClient(
+		xata.WithAPIKey(cfg.apiKey),
+		xata.WithBaseURL(fmt.Sprintf(
+			"https://%s.%s.xata.sh",
+			cfg.wsID,
+			cfg.region,
+		)),
+		xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()),
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	ctx := context.Background()
 	t.Run("should create/delete, get schema and columns of a table and add/delete column", func(t *testing.T) {
-		httpCli := retryablehttp.NewClient().StandardClient()
-
-		workspaceCli, err := xata.NewWorkspacesClient(
-			xata.WithAPIKey(apiKey),
-			xata.WithHTTPClient(httpCli),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		testID := testIdentifier()
-
-		ws, err := workspaceCli.Create(
-			context.Background(),
-			&xata.WorkspaceMeta{Name: "ws_name_" + testID},
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		t.Cleanup(func() {
-			err := workspaceCli.Delete(ctx, ws.Id)
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		databaseCli, err := xata.NewDatabasesClient(
-			xata.WithAPIKey(apiKey),
-			xata.WithHTTPClient(httpCli),
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		listRegionsResponse, err := databaseCli.GetRegionsWithWorkspaceID(ctx, ws.Id)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		regionID := listRegionsResponse.Regions[0].Id
-
 		db, err := databaseCli.Create(ctx, xata.CreateDatabaseRequest{
 			DatabaseName: "db_name_" + testID,
-			WorkspaceID:  xata.String(ws.Id),
-			Region:       &regionID,
-			UI:           &xata.UI{Color: xata.String("RED")},
-			BranchMetaData: &xata.BranchMetadata{
-				Repository: xata.String("github.com/my/repository"),
-				Branch:     xata.String("feature-branch"),
-				Stage:      xata.String("testing"),
-				Labels:     &[]string{"development"},
-			},
+			WorkspaceID:  xata.String(cfg.wsID),
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		t.Cleanup(func() {
-			_, err = databaseCli.Delete(ctx, xata.DeleteDatabaseRequest{
-				WorkspaceID:  xata.String(ws.Id),
-				DatabaseName: db.DatabaseName,
-			})
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		tableCli, err := xata.NewTableClient(
-			xata.WithAPIKey(apiKey),
-			xata.WithBaseURL(fmt.Sprintf(
-				"https://%s.%s.xata.sh",
-				ws.Id,
-				regionID,
-			)),
-			xata.WithHTTPClient(retryablehttp.NewClient().StandardClient()),
-		)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,5 +112,15 @@ func Test_tableClient(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		t.Cleanup(func() {
+			_, err = databaseCli.Delete(ctx, xata.DeleteDatabaseRequest{
+				WorkspaceID:  xata.String(cfg.wsID),
+				DatabaseName: db.DatabaseName,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	})
 }

--- a/xata/utils.go
+++ b/xata/utils.go
@@ -161,11 +161,11 @@ func loadConfig(fieName string) (config, error) {
 	return cfg, nil
 }
 
-// getBranchName retrieves the branch name.
-// If not found, falls back to defaultBranchName
-func getBranchName() string {
-	if branchName, found := os.LookupEnv(branchNameEnvVar); found {
-		return branchName
+// Get value from env var with fallback to godotenv
+// return default value if not found
+func getEnvVar(name string, defaultValue string) string {
+	if val, found := os.LookupEnv(name); found {
+		return val
 	}
 
 	var myEnv map[string]string
@@ -177,20 +177,22 @@ func getBranchName() string {
 		}
 	}
 
-	if branchName, found := myEnv[branchNameEnvVar]; found {
-		return branchName
+	if val, found := myEnv[name]; found {
+		return val
 	}
+	return defaultValue
+}
 
-	return defaultBranchName
+// getBranchName retrieves the branch name.
+// If not found, falls back to defaultBranchName
+func getBranchName() string {
+	return getEnvVar(branchNameEnvVar, defaultBranchName)
 }
 
 // Get the region if the corresponding env var `XATA_REGION` is set
 // otherwise return the default region: us-east-1
 func getRegion() string {
-	if region, found := os.LookupEnv("XATA_REGION"); found {
-		return region
-	}
-	return defaultRegion
+	return getEnvVar("XATA_REGION", defaultRegion)
 }
 
 // loadDatabaseConfig will return config with defaults if the error is not nil.
@@ -200,9 +202,11 @@ func loadDatabaseConfig() (databaseConfig, error) {
 		branchName:      defaultBranchName,
 		domainWorkspace: defaultDataPlaneDomain,
 	}
+
 	// Setup with env var
 	// XATA_WORKSPACE_ID to set the workspace Id
-	if wsID, found := os.LookupEnv("XATA_WORKSPACE_ID"); found {
+	wsID := getEnvVar("XATA_WORKSPACE_ID", "")
+	if wsID != "" {
 		region := getRegion()
 		branch := getBranchName()
 		db := databaseConfig{

--- a/xata/utils.go
+++ b/xata/utils.go
@@ -18,13 +18,14 @@ const (
 	personalAPIKeyLocation    = "~/.config/xata/key"
 	defaultControlPlaneDomain = "api.xata.io"
 	xataAPIKeyEnvVar          = "XATA_API_KEY"
-	xataWsIDEnvVar            = "XATA_WORKSPACE_ID" // TODO: not in use yet
+	xataWsIDEnvVar            = "XATA_WORKSPACE_ID"
 	dbURLFormat               = "https://{workspace_id}.{region}.xata.sh/db/{db_name}:{branch_name}"
 	defaultBranchName         = "main"
 	configFileName            = ".xatarc"
 	branchNameEnvVar          = "XATA_BRANCH"
 	defaultDataPlaneDomain    = "xata.sh"
 	defaultRegion             = "us-east-1"
+	regionEnvVar              = "XATA_REGION"
 )
 
 var errAPIKey = fmt.Errorf("no API key found. Searched in `%s` env, %s, and .env", xataAPIKeyEnvVar, personalAPIKeyLocation)
@@ -192,7 +193,7 @@ func getBranchName() string {
 // Get the region if the corresponding env var `XATA_REGION` is set
 // otherwise return the default region: us-east-1
 func getRegion() string {
-	return getEnvVar("XATA_REGION", defaultRegion)
+	return getEnvVar(regionEnvVar, defaultRegion)
 }
 
 // loadDatabaseConfig will return config with defaults if the error is not nil.
@@ -205,7 +206,7 @@ func loadDatabaseConfig() (databaseConfig, error) {
 
 	// Setup with env var
 	// XATA_WORKSPACE_ID to set the workspace Id
-	wsID := getEnvVar("XATA_WORKSPACE_ID", "")
+	wsID := getEnvVar(xataWsIDEnvVar, "")
 	if wsID != "" {
 		region := getRegion()
 		branch := getBranchName()

--- a/xata/utils.go
+++ b/xata/utils.go
@@ -184,6 +184,15 @@ func getBranchName() string {
 	return defaultBranchName
 }
 
+// Get the region if the corresponding env var `XATA_REGION` is set
+// otherwise return the default region: us-east-1
+func getRegion() string {
+	if region, found := os.LookupEnv("XATA_REGION"); found {
+		return region
+	}
+	return defaultRegion
+}
+
 // loadDatabaseConfig will return config with defaults if the error is not nil.
 func loadDatabaseConfig() (databaseConfig, error) {
 	defaultDBConfig := databaseConfig{
@@ -191,6 +200,19 @@ func loadDatabaseConfig() (databaseConfig, error) {
 		branchName:      defaultBranchName,
 		domainWorkspace: defaultDataPlaneDomain,
 	}
+	// Setup with env var
+	// XATA_WORKSPACE_ID to set the workspace Id
+	if wsID, found := os.LookupEnv("XATA_WORKSPACE_ID"); found {
+		region := getRegion()
+		branch := getBranchName()
+		db := databaseConfig{
+			workspaceID: wsID,
+			region:      region,
+			branchName:  branch,
+		}
+		return db, nil
+	}
+
 	cfg, err := loadConfig(configFileName)
 	if err != nil {
 		return defaultDBConfig, err

--- a/xata/utils_test.go
+++ b/xata/utils_test.go
@@ -56,7 +56,7 @@ func Test_getRegion(t *testing.T) {
 	})
 
 	setRegion := "eu-west-3"
-	err := os.Setenv("XATA_REGION", setRegion)
+	err := os.Setenv(regionEnvVar, setRegion)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func Test_getRegion(t *testing.T) {
 		assert.Equal(t, gotRegion, setRegion)
 	})
 
-	t.Cleanup(func() { os.Unsetenv("XATA_REGION") })
+	t.Cleanup(func() { os.Unsetenv(regionEnvVar) })
 }
 
 func Test_parseDatabaseURL(t *testing.T) {
@@ -176,7 +176,7 @@ func Test_loadConfig(t *testing.T) {
 
 func Test_loadDatabaseConfig_with_envvars(t *testing.T) {
 	setWsId := "workspace-0lac00"
-	err := os.Setenv("XATA_WORKSPACE_ID", setWsId)
+	err := os.Setenv(xataWsIDEnvVar, setWsId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,13 +205,13 @@ func Test_loadDatabaseConfig_with_envvars(t *testing.T) {
 		t.Fatal(err2)
 	}
 	setRegion := "ap-southeast-16"
-	err3 := os.Setenv("XATA_REGION", setRegion)
+	err3 := os.Setenv(regionEnvVar, setRegion)
 	if err3 != nil {
 		t.Fatal(err3)
 	}
 
 	// with branch and region env vars
-	t.Run("load config from XATA_WORKSPACE_ID, XATA_REGION and XATA_BRANCH env vars", func(t *testing.T) {
+	t.Run("load config from XATA_WORKSPACE_ID, regionEnvVar and XATA_BRANCH env vars", func(t *testing.T) {
 		dbCfg, err := loadDatabaseConfig()
 		if err != nil {
 			t.Fatalf("Error loading config: %v", err)
@@ -229,8 +229,8 @@ func Test_loadDatabaseConfig_with_envvars(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		os.Unsetenv("XATA_WORKSPACE_ID")
-		os.Unsetenv("XATA_BRANCH")
-		os.Unsetenv("XATA_REGION")
+		os.Unsetenv(xataWsIDEnvVar)
+		os.Unsetenv(branchNameEnvVar)
+		os.Unsetenv(regionEnvVar)
 	})
 }

--- a/xata/utils_test.go
+++ b/xata/utils_test.go
@@ -26,6 +26,50 @@ func TestClientOptions_getAPIKey(t *testing.T) {
 	})
 }
 
+func Test_getBranchName(t *testing.T) {
+	// default state
+	t.Run("should be default branch name", func(t *testing.T) {
+		gotBranchName := getBranchName()
+		assert.Equal(t, gotBranchName, defaultBranchName)
+	})
+
+	setBranchName := "feature-042"
+	err := os.Setenv(branchNameEnvVar, setBranchName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// from env var
+	t.Run("should be branch name from env var", func(t *testing.T) {
+		gotBranchName := getBranchName()
+		assert.Equal(t, gotBranchName, setBranchName)
+	})
+
+	t.Cleanup(func() { os.Unsetenv(branchNameEnvVar) })
+}
+
+func Test_getRegion(t *testing.T) {
+	// default state
+	t.Run("should be default region", func(t *testing.T) {
+		gotRegion := getRegion()
+		assert.Equal(t, gotRegion, defaultRegion)
+	})
+
+	setRegion := "eu-west-3"
+	err := os.Setenv("XATA_REGION", setRegion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// from env var
+	t.Run("should be region from the env var", func(t *testing.T) {
+		gotRegion := getRegion()
+		assert.Equal(t, gotRegion, setRegion)
+	})
+
+	t.Cleanup(func() { os.Unsetenv("XATA_REGION") })
+}
+
 func Test_parseDatabaseURL(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -95,6 +139,7 @@ func Test_parseDatabaseURL(t *testing.T) {
 }
 
 func Test_loadConfig(t *testing.T) {
+	// from .xatarc
 	t.Run("should read database URL", func(t *testing.T) {
 		// Create a temporary JSON file for testing
 		tempFile, err := os.CreateTemp("", "config_test.json")
@@ -126,5 +171,66 @@ func Test_loadConfig(t *testing.T) {
 		if cfg.DatabaseURL != expectedURL {
 			t.Fatalf("Expected database URL: %s, got: %s", expectedURL, cfg.DatabaseURL)
 		}
+	})
+}
+
+func Test_loadDatabaseConfig_with_envvars(t *testing.T) {
+	setWsId := "workspace-0lac00"
+	err := os.Setenv("XATA_WORKSPACE_ID", setWsId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test workspace id from env var
+	t.Run("load config from WORKSPACE_ID env var", func(t *testing.T) {
+		dbCfg, err := loadDatabaseConfig()
+		if err != nil {
+			t.Fatalf("Error loading config: %v", err)
+		}
+
+		if dbCfg.workspaceID != setWsId {
+			t.Fatalf("Expected Workspace ID: %s, got: %s", setWsId, dbCfg.workspaceID)
+		}
+		if dbCfg.branchName != defaultBranchName {
+			t.Fatalf("Expected branch name: %s, got: %s", defaultBranchName, dbCfg.branchName)
+		}
+		if dbCfg.region != defaultRegion {
+			t.Fatalf("Expected region: %s, got: %s", defaultRegion, dbCfg.region)
+		}
+	})
+
+	setBranch := "branch123"
+	err2 := os.Setenv(branchNameEnvVar, setBranch)
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	setRegion := "ap-southeast-16"
+	err3 := os.Setenv("XATA_REGION", setRegion)
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+
+	// with branch and region env vars
+	t.Run("load config from XATA_WORKSPACE_ID, XATA_REGION and XATA_BRANCH env vars", func(t *testing.T) {
+		dbCfg, err := loadDatabaseConfig()
+		if err != nil {
+			t.Fatalf("Error loading config: %v", err)
+		}
+
+		if dbCfg.workspaceID != setWsId {
+			t.Fatalf("Expected Workspace ID: %s, got: %s", setWsId, dbCfg.workspaceID)
+		}
+		if dbCfg.branchName != setBranch {
+			t.Fatalf("Expected branch name: %s, got: %s", setBranch, dbCfg.branchName)
+		}
+		if dbCfg.region != setRegion {
+			t.Fatalf("Expected region: %s, got: %s", setRegion, dbCfg.region)
+		}
+	})
+
+	t.Cleanup(func() {
+		os.Unsetenv("XATA_WORKSPACE_ID")
+		os.Unsetenv("XATA_BRANCH")
+		os.Unsetenv("XATA_REGION")
 	})
 }


### PR DESCRIPTION
The workspace Id can be set via env var `XATA_WORKSPACE_ID`. This env var takes precedence over the `.xatarc` file. The `XATA_WORKSPACE_ID` is present, there is an additional lookup for the env vars `XATA_BRANCH` and `XATA_REGION`.